### PR TITLE
Fixes 'Object of class stdClass could not be converted to string'

### DIFF
--- a/src/Zoom.php
+++ b/src/Zoom.php
@@ -110,7 +110,7 @@ class Zoom
         $apiCall = self::API_URL . $function . (('GET' === $method) ? $paramString : null);
 
         $headerData = [
-            'Authorization: Bearer ' . $this->getAccessToken(),
+            'Authorization: Bearer ' . $this->getAccessToken()->access_token,
             'Accept: application/json'
         ];
 


### PR DESCRIPTION
Fixes the following error:
at HandleExceptions->handleError('4096', 'Object of class stdClass could not be converted to string', '\vendor\espresso-dev\zoom-php\src\Zoom.php', '113', array('function' => 'users/me/meetings', 'params' => array('type' => 'scheduled', 'page_size' => '30', 'page_number' => '1'), 'method' => 'GET', 'paramString' => '?type=scheduled&page_size=30&page_number=1', 'apiCall' => 'https://api.zoom.us/v2/users/me/meetings?type=scheduled&page_size=30&page_number=1')) in Zoom.php line 113